### PR TITLE
Add THIRD-PARTY-LICENSES with template's license

### DIFF
--- a/{{ cookiecutter.project_name }}/THIRD-PARTY-LICENSES
+++ b/{{ cookiecutter.project_name }}/THIRD-PARTY-LICENSES
@@ -1,0 +1,25 @@
+*******************************************************************************
+https://github.com/Afonasev/cookiecutter-pypackage-poetry
+*******************************************************************************
+
+MIT License
+
+Copyright (c) 2019 Afonasev Evgeniy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Since the template is MIT-licensed, developers who use the template must state the fact that they used it and include a copy of its license.

This PR makes it automatic by including the original license into the template.  This way, responsible developers won't have to do extra work, and irresponsible developers won't accidentally break the license.